### PR TITLE
MOD: fix max bib names number to conform to NCS style

### DIFF
--- a/ncs-citation.cbx
+++ b/ncs-citation.cbx
@@ -13,9 +13,9 @@
 \RequireCitationStyle{numeric-comp}
 
 \ExecuteBibliographyOptions{
-    maxcitenames = 2,
     mincitenames = 1,
-    maxbibnames  = 99,
+    maxcitenames = 2,
+    maxbibnames  = 2,
     sorting      = none
 }
 


### PR DESCRIPTION
# Max bib names number
* maxbibnames = 99 -> maxbibnames = 2